### PR TITLE
Oudated statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is "intelligent" in this sense that it automatically selects the ri
 
 ## Supported Formats
 
-* CSV via <https://github.com/JuliaData/CSV.jl> (installed as core depencency of TableIO)
+* CSV via <https://github.com/JuliaData/CSV.jl>
 * JSON via <https://github.com/JuliaData/JSONTables.jl>
 * Zipped CSV or JSON via <https://github.com/fhs/ZipFile.jl>
 * JDF via <https://github.com/xiaodaigh/JDF.jl>


### PR DESCRIPTION
[skip ci]

https://github.com/lungben/TableIO.jl/commit/adaccaad331c489d7220a637093d0d713b3be4ad

It's not clear why Pandas.jl used instead:
https://github.com/lungben/TableIO.jl/commit/4ea627dc371e364aa60fbc93be8716b508916650#diff-72ed386c2a0cd1d23c0968297e70023ed98c22490d146dd89fc91f48369bad4d